### PR TITLE
feat(clowder-v2): migrate kessel-inventory to V2 dependency endpoint

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,6 +4,7 @@ import json
 import os
 import tempfile
 from datetime import timedelta
+from urllib.parse import urlsplit
 
 from app_common_python import DependencyEndpoints
 from app_common_python import get_v2_dependency_endpoint
@@ -58,13 +59,36 @@ class Config:
 
         cfg = app_common_python.LoadedConfig
 
-        # Only configure Kessel from DependencyEndpoints if the dependency exists
-        try:
-            kessel_inventory_hostname = DependencyEndpoints["kessel-inventory"]["api"].hostname
-            kessel_inventory_port = os.environ.get("KESSEL_INVENTORY_API_PORT", "9000")
-            self.kessel_inventory_api_endpoint = f"{kessel_inventory_hostname}:{kessel_inventory_port}"
-        except KeyError:
-            self.kessel_inventory_api_endpoint = os.environ.get("KESSEL_INVENTORY_API_ENDPOINT", "localhost:9000")
+        # Prefer the Clowder V2 dependency endpoint (carries uri/ca_certificate/authenticated) when
+        # kessel-inventory is served via a V2-aware ClowdApp/ClowdAppRef. Fall back to the V1
+        # DependencyEndpoints hostname lookup, then to a plain env var, for environments where
+        # kessel-inventory is still V1-only or not declared as a dependency at all.
+        #
+        # KESSEL_INVENTORY_API_PORT overrides the port even on the V2 path. This isn't just a V1
+        # leftover: Clowder V2 endpoints get populated for kessel-inventory's real in-cluster
+        # ClowdApp too, but it hides its actual gRPC port behind a non-standard h2cTargetPort=9000
+        # (rather than a standard public/private port), so the V2-reported port is wrong for that
+        # deployment. The override lets one codebase correctly serve both a ClowdAppRef consumer
+        # (where remoteEnvironment.tls.port is explicitly correct, e.g. 443 -- no override needed)
+        # and an in-cluster ClowdApp consumer (V2 port is wrong -- override supplies the real one)
+        # during the transition. See https://github.com/RedHatInsights/insights-host-inventory/pull/4878
+        # discussion for the full reasoning.
+        self._kessel_v2_endpoint = get_v2_dependency_endpoint("kessel-inventory", "api")
+        if self._kessel_v2_endpoint is not None:
+            v2_host = urlsplit(self._kessel_v2_endpoint.uri).hostname
+            v2_port = urlsplit(self._kessel_v2_endpoint.uri).port
+            kessel_inventory_port = os.environ.get("KESSEL_INVENTORY_API_PORT") or v2_port
+            self.kessel_inventory_api_endpoint = f"{v2_host}:{kessel_inventory_port}"
+        else:
+            try:
+                kessel_inventory_hostname = DependencyEndpoints["kessel-inventory"]["api"].hostname
+                # NOTE: os.environ.get(key, default) would NOT fall through here if the ClowdApp
+                # template sets KESSEL_INVENTORY_API_PORT="" (its new blank default) -- an empty
+                # string is a present value, not a missing key. `or` is required, not cosmetic.
+                kessel_inventory_port = os.environ.get("KESSEL_INVENTORY_API_PORT") or "9000"
+                self.kessel_inventory_api_endpoint = f"{kessel_inventory_hostname}:{kessel_inventory_port}"
+            except KeyError:
+                self.kessel_inventory_api_endpoint = os.environ.get("KESSEL_INVENTORY_API_ENDPOINT", "localhost:9000")
 
         self.is_clowder = True
         self.metrics_port = cfg.metricsPort
@@ -178,6 +202,7 @@ class Config:
         self.rbac_endpoint = os.environ.get("RBAC_ENDPOINT", "http://localhost:8111")
         self.rbac_endpoint_ca_certificate = None
         self.rbac_endpoint_authenticated = False
+        self._kessel_v2_endpoint = None
         self.kessel_inventory_api_endpoint = os.environ.get("KESSEL_INVENTORY_API_ENDPOINT", "localhost:9000")
         self.export_service_endpoint = os.environ.get("EXPORT_SERVICE_ENDPOINT", "http://localhost:10010")
         self.export_service_endpoint_ca_certificate = None
@@ -261,8 +286,14 @@ class Config:
         self.kessel_auth_oidc_issuer = os.getenv(
             "KESSEL_AUTH_OIDC_ISSUER", "https://sso.redhat.com/auth/realms/redhat-external"
         )
-        self.kessel_auth_enabled = os.environ.get("KESSEL_AUTH_ENABLED", "false").lower() == "true"
-        self.kessel_insecure = os.environ.get("KESSEL_INSECURE", "true").lower() == "true"
+        if self._kessel_v2_endpoint is not None:
+            self.kessel_auth_enabled = bool(self._kessel_v2_endpoint.authenticated)
+            self.kessel_insecure = urlsplit(self._kessel_v2_endpoint.uri).scheme != "https"
+            self.kessel_ca_certificate = self._kessel_v2_endpoint.ca_certificate
+        else:
+            self.kessel_auth_enabled = os.environ.get("KESSEL_AUTH_ENABLED", "false").lower() == "true"
+            self.kessel_insecure = os.environ.get("KESSEL_INSECURE", "true").lower() == "true"
+            self.kessel_ca_certificate = None
 
         self.bypass_unleash = os.environ.get("BYPASS_UNLEASH", "false").lower() == "true"
         self.unleash_refresh_interval = int(os.environ.get("UNLEASH_REFRESH_INTERVAL", "15"))
@@ -517,6 +548,9 @@ class Config:
 
             self.logger.info("Kessel Bypassed: %s", self.bypass_kessel)
             self.logger.info("Kessel is running in %s mode.", "INSECURE" if self.kessel_insecure else "SECURE")
+            self.logger.info("Kessel Endpoint Authenticated: %s", self.kessel_auth_enabled)
+            if self.kessel_ca_certificate:
+                self.logger.info("Kessel Endpoint CA Certificate: %s", self.kessel_ca_certificate)
             self.logger.info("V2 API Enabled: %s", self.v2_api_enabled)
 
             self.logger.info("Unleash (feature flags) Bypassed by config: %s", self.bypass_unleash)

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -3150,9 +3150,14 @@ parameters:
 - description: OIDC issuer URL used for Kessel auth token requests
   name: KESSEL_AUTH_OIDC_ISSUER
   value: https://sso.redhat.com/auth/realms/redhat-external
-- description: Port for the Kessel inventory gRPC API endpoint
+- description: >-
+    Overrides the Kessel inventory gRPC port even when a Clowder V2 dependency endpoint is
+    resolved. Blank by default so a correctly-configured ClowdAppRef (e.g. stage, pointing at the
+    HCC gateway on 443) is trusted as-is. Set explicitly (e.g. 9000) only for environments still
+    using kessel-inventory's real in-cluster ClowdApp, whose V2-reported port is wrong due to its
+    non-standard h2cTargetPort setup.
   name: KESSEL_INVENTORY_API_PORT
-  value: '9000'
+  value: ''
 - description: How long to wait for DB migrations to complete
   name: WAIT_FOR_MIGRATIONS_TIMEOUT_SECONDS
   value: '300'

--- a/lib/kessel.py
+++ b/lib/kessel.py
@@ -49,14 +49,26 @@ def get_kessel_oauth2_credentials(config: Config) -> OAuth2ClientCredentials:
 
 class Kessel:
     def __init__(self, config: Config):
+        # A CA certificate is only ever present when the Clowder V2 dependency endpoint supplied
+        # one; V1/env-var-configured deployments pass None here and get the SDK's system-trust-store
+        # default (see ClientBuilder._build_credentials()).
+        channel_credentials = None
+        ca_certificate = getattr(config, "kessel_ca_certificate", None)
+        if ca_certificate:
+            with open(ca_certificate, "rb") as f:
+                channel_credentials = grpc.ssl_channel_credentials(root_certificates=f.read())
+
         client_builder = ClientBuilder(config.kessel_inventory_api_endpoint)
 
         if config.kessel_auth_enabled:
             auth_credentials = get_kessel_oauth2_credentials(config)
-            client_builder = client_builder.oauth2_client_authenticated(auth_credentials)
-
-        if config.kessel_insecure:
+            client_builder = client_builder.oauth2_client_authenticated(
+                auth_credentials, channel_credentials=channel_credentials
+            )
+        elif config.kessel_insecure:
             client_builder = client_builder.insecure()
+        else:
+            client_builder = client_builder.authenticated(channel_credentials=channel_credentials)
 
         self.inventory_svc, self.channel = client_builder.build()
         self.timeout = getattr(config, "kessel_timeout", 10.0)  # Default 10 second timeout

--- a/tests/test_lib_kessel.py
+++ b/tests/test_lib_kessel.py
@@ -68,6 +68,84 @@ def mock_subject_ref() -> subject_reference_pb2.SubjectReference:
     return subject_reference_pb2.SubjectReference(resource=resource_ref)
 
 
+class TestKesselClientInit:
+    """Tests for Kessel.__init__'s channel/auth credential selection.
+
+    JIRA: RHCLOUD-48029
+    """
+
+    def _make_config(self, mocker, *, auth_enabled=False, insecure=True, ca_certificate=None):
+        config = mocker.Mock()
+        config.kessel_inventory_api_endpoint = "kessel-inventory.example.com:9000"
+        config.kessel_auth_enabled = auth_enabled
+        config.kessel_insecure = insecure
+        config.kessel_ca_certificate = ca_certificate
+        config.kessel_timeout = 10.0
+        return config
+
+    def test_insecure_channel_when_no_auth_and_insecure(self, mocker) -> None:
+        """Legacy/dev V1 default: no auth, insecure channel."""
+        mock_builder = mocker.patch("lib.kessel.ClientBuilder").return_value
+        mock_builder.insecure.return_value = mock_builder
+        mock_builder.build.return_value = (Mock(), Mock())
+
+        config = self._make_config(mocker, auth_enabled=False, insecure=True)
+        Kessel(config)
+
+        mock_builder.insecure.assert_called_once()
+        mock_builder.oauth2_client_authenticated.assert_not_called()
+        mock_builder.authenticated.assert_not_called()
+
+    def test_oauth2_authenticated_with_ca_certificate(self, mocker, tmp_path) -> None:
+        """V2 dependency endpoint target state: OAuth2 auth over TLS with a custom CA."""
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_bytes(b"fake-ca-bytes")
+
+        mock_builder = mocker.patch("lib.kessel.ClientBuilder").return_value
+        mock_builder.oauth2_client_authenticated.return_value = mock_builder
+        mock_builder.build.return_value = (Mock(), Mock())
+        mocker.patch("lib.kessel.grpc.ssl_channel_credentials", return_value="mock-channel-creds")
+        mock_get_creds = mocker.patch("lib.kessel.get_kessel_oauth2_credentials", return_value="mock-auth-creds")
+
+        config = self._make_config(mocker, auth_enabled=True, insecure=False, ca_certificate=str(ca_file))
+        Kessel(config)
+
+        mock_get_creds.assert_called_once_with(config)
+        mock_builder.oauth2_client_authenticated.assert_called_once_with(
+            "mock-auth-creds", channel_credentials="mock-channel-creds"
+        )
+        mock_builder.insecure.assert_not_called()
+        mock_builder.authenticated.assert_not_called()
+
+    def test_oauth2_authenticated_without_ca_certificate_uses_system_trust(self, mocker) -> None:
+        """No CA certificate (V1 fallback path) -> channel_credentials stays None (system trust)."""
+        mock_builder = mocker.patch("lib.kessel.ClientBuilder").return_value
+        mock_builder.oauth2_client_authenticated.return_value = mock_builder
+        mock_builder.build.return_value = (Mock(), Mock())
+        mock_get_creds = mocker.patch("lib.kessel.get_kessel_oauth2_credentials", return_value="mock-auth-creds")
+
+        config = self._make_config(mocker, auth_enabled=True, insecure=False, ca_certificate=None)
+        Kessel(config)
+
+        mock_get_creds.assert_called_once_with(config)
+        mock_builder.oauth2_client_authenticated.assert_called_once_with(
+            "mock-auth-creds", channel_credentials=None
+        )
+
+    def test_secure_unauthenticated_uses_authenticated_builder(self, mocker) -> None:
+        """Neither insecure nor auth-enabled -> plain TLS via the `authenticated()` builder method."""
+        mock_builder = mocker.patch("lib.kessel.ClientBuilder").return_value
+        mock_builder.authenticated.return_value = mock_builder
+        mock_builder.build.return_value = (Mock(), Mock())
+
+        config = self._make_config(mocker, auth_enabled=False, insecure=False, ca_certificate=None)
+        Kessel(config)
+
+        mock_builder.authenticated.assert_called_once_with(channel_credentials=None)
+        mock_builder.insecure.assert_not_called()
+        mock_builder.oauth2_client_authenticated.assert_not_called()
+
+
 class TestCheckBulkResourcesFeatureFlag:
     """Tests for _check_bulk_resources with feature flag control."""
 


### PR DESCRIPTION
Extends the V2 dependency endpoint migration (rbac, export-service) to kessel-inventory itself: resolve via `get_v2_dependency_endpoint` first, falling back to the existing V1 `DependencyEndpoints` lookup, then env var.

`KESSEL_INVENTORY_API_PORT` stays overridable even on the V2 path (not just V1 fallback) and its `clowdapp.yml` default changes from '9000' to '': Clowder auto-populates a V2 endpoint for kessel-inventory's real in-cluster ClowdApp too, but reports the wrong port (`h2cTargetPort=9000` instead of a standard public/private port). The override lets one codebase serve both a ClowdAppRef consumer (correct V2 port, e.g. `443` via the HCC gateway) and an in-cluster ClowdApp consumer (wrong V2 port, needs the override) during the transition. A non-blank template default would always be present in the pod env and would silently clobber a correct V2-derived port, so the default has to be blank rather than `9000`.

`lib/kessel.py`: build `channel_credentials` from `kessel_ca_certificate` when Clowder supplies one (system trust store when absent, confirmed via kessel-sdk's own `ClientBuilder._build_credentials()`), and branch auth/insecure/plain-TLS via if/elif/else instead of two independent ifs.

Assisted by: Claude Code (claude-sonnet-5)